### PR TITLE
Raise ValueError with wrong window size in UIQ

### DIFF
--- a/image_similarity_measures/quality_metrics.py
+++ b/image_similarity_measures/quality_metrics.py
@@ -27,7 +27,8 @@ def rmse(org_img: np.ndarray, pred_img: np.ndarray, max_p=4095) -> float:
 
     rmse_bands = []
     for i in range(org_img.shape[2]):
-        m = np.mean(np.square(((org_img[:, :, i] - pred_img[:, :, i]) / max_p).astype(org_img.dtype)))
+        dif = np.subtract(org_img, pred_img)
+        m = np.mean(np.square( dif / max_p))
         s = np.sqrt(m)
         rmse_bands.append(s)
 

--- a/image_similarity_measures/quality_metrics.py
+++ b/image_similarity_measures/quality_metrics.py
@@ -213,7 +213,7 @@ def uiq(org_img: np.ndarray, pred_img: np.ndarray, step_size=1, window_size=8):
                                                        sliding_window(pred_img, stepSize=step_size,
                                                                       windowSize=(window_size, window_size))):
         # if the window does not meet our desired window size, ignore it
-        if window_org.shape[0] != 8 or window_org.shape[1] != 8:
+        if window_org.shape[0] != window_size or window_org.shape[1] != window_size:
             continue
 
         for i in range(org_img.shape[2]):
@@ -231,6 +231,10 @@ def uiq(org_img: np.ndarray, pred_img: np.ndarray, step_size=1, window_size=8):
             if denominator != 0.0:
                 q = numerator / denominator
                 q_all.append(q)
+
+    if not np.any(q_all):
+        raise ValueError(f"Window size ({window_size}) is too big for image with shape "
+                         f"{org_img.shape[0:2]}, please use a smaller window size.")
 
     return np.mean(q_all)
 

--- a/image_similarity_measures/quality_metrics.py
+++ b/image_similarity_measures/quality_metrics.py
@@ -16,9 +16,6 @@ def _assert_image_shapes_equal(org_img: np.ndarray, pred_img: np.ndarray, metric
 
     assert org_img.shape == pred_img.shape, msg
 
-def _to_float(org_img: np.ndarray, pred_img: np.ndarray):
-    return org_img.astype(np.float32), pred_img.astype(np.float32)
-
 def rmse(org_img: np.ndarray, pred_img: np.ndarray, max_p=4095) -> float:
     """
     Root Mean Squared Error
@@ -26,7 +23,8 @@ def rmse(org_img: np.ndarray, pred_img: np.ndarray, max_p=4095) -> float:
     Calculated individually for all bands, then averaged
     """
     _assert_image_shapes_equal(org_img, pred_img, "RMSE")
-    org_img, pred_img = _to_float(org_img, pred_img)
+
+    org_img = org_img.astype(np.float32)
 
     rmse_bands = []
     for i in range(org_img.shape[2]):
@@ -49,7 +47,8 @@ def psnr(org_img: np.ndarray, pred_img: np.ndarray, max_p=4095) -> float:
     0 and 1 (e.g. unscaled reflectance) the first logarithmic term can be dropped as it becomes 0
     """
     _assert_image_shapes_equal(org_img, pred_img, "PSNR")
-    org_img, pred_img = _to_float(org_img, pred_img)
+
+    org_img = org_img.astype(np.float32)
 
     mse_bands = []
     for i in range(org_img.shape[2]):
@@ -212,7 +211,10 @@ def uiq(org_img: np.ndarray, pred_img: np.ndarray, step_size=1, window_size=8):
     """
     # TODO: Apply optimization, right now it is very slow
     _assert_image_shapes_equal(org_img, pred_img, "UIQ")
-    org_img, pred_img = _to_float(org_img, pred_img)
+
+    org_img = org_img.astype(np.float32)
+    pred_img = pred_img.astype(np.float32)
+
     q_all = []
     for (x, y, window_org), (x, y, window_pred) in zip(sliding_window(org_img, stepSize=step_size,
                                                                       windowSize=(window_size, window_size)),
@@ -270,7 +272,8 @@ def sre(org_img: np.ndarray, pred_img: np.ndarray):
     signal to reconstruction error ratio
     """
     _assert_image_shapes_equal(org_img, pred_img, "SRE")
-    org_img, pred_img = _to_float(org_img, pred_img)
+
+    org_img = org_img.astype(np.float32)
 
     sre_final = []
     for i in range(org_img.shape[2]):

--- a/image_similarity_measures/quality_metrics.py
+++ b/image_similarity_measures/quality_metrics.py
@@ -27,7 +27,7 @@ def rmse(org_img: np.ndarray, pred_img: np.ndarray, max_p=4095) -> float:
 
     rmse_bands = []
     for i in range(org_img.shape[2]):
-        m = np.mean(np.square((org_img[:, :, i] - pred_img[:, :, i]) / max_p))
+        m = np.mean(np.square(((org_img[:, :, i] - pred_img[:, :, i]) / max_p).astype(org_img.dtype)))
         s = np.sqrt(m)
         rmse_bands.append(s)
 

--- a/image_similarity_measures/quality_metrics.py
+++ b/image_similarity_measures/quality_metrics.py
@@ -179,7 +179,7 @@ def issm(org_img: np.ndarray, pred_img: np.ndarray) -> float:
     A = 0.3
     B = 0.5
     C = 0.7
-    
+
     ehs_val = _ehs(x, y)
     canny_val = _edge_c(x, y)
 
@@ -212,6 +212,7 @@ def uiq(org_img: np.ndarray, pred_img: np.ndarray, step_size=1, window_size=8):
     """
     # TODO: Apply optimization, right now it is very slow
     _assert_image_shapes_equal(org_img, pred_img, "UIQ")
+    org_img, pred_img = _to_float(org_img, pred_img)
     q_all = []
     for (x, y, window_org), (x, y, window_pred) in zip(sliding_window(org_img, stepSize=step_size,
                                                                       windowSize=(window_size, window_size)),
@@ -269,6 +270,7 @@ def sre(org_img: np.ndarray, pred_img: np.ndarray):
     signal to reconstruction error ratio
     """
     _assert_image_shapes_equal(org_img, pred_img, "SRE")
+    org_img, pred_img = _to_float(org_img, pred_img)
 
     sre_final = []
     for i in range(org_img.shape[2]):

--- a/image_similarity_measures/quality_metrics.py
+++ b/image_similarity_measures/quality_metrics.py
@@ -16,6 +16,8 @@ def _assert_image_shapes_equal(org_img: np.ndarray, pred_img: np.ndarray, metric
 
     assert org_img.shape == pred_img.shape, msg
 
+def _to_float(org_img: np.ndarray, pred_img: np.ndarray):
+    return org_img.astype(np.float32), pred_img.astype(np.float32)
 
 def rmse(org_img: np.ndarray, pred_img: np.ndarray, max_p=4095) -> float:
     """
@@ -24,6 +26,7 @@ def rmse(org_img: np.ndarray, pred_img: np.ndarray, max_p=4095) -> float:
     Calculated individually for all bands, then averaged
     """
     _assert_image_shapes_equal(org_img, pred_img, "RMSE")
+    org_img, pred_img = _to_float(org_img, pred_img)
 
     rmse_bands = []
     for i in range(org_img.shape[2]):
@@ -46,6 +49,7 @@ def psnr(org_img: np.ndarray, pred_img: np.ndarray, max_p=4095) -> float:
     0 and 1 (e.g. unscaled reflectance) the first logarithmic term can be dropped as it becomes 0
     """
     _assert_image_shapes_equal(org_img, pred_img, "PSNR")
+    org_img, pred_img = _to_float(org_img, pred_img)
 
     mse_bands = []
     for i in range(org_img.shape[2]):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="image-similarity-measures",
-    version="0.3.0",
+    version="0.3.1",
     author="UP42",
     author_email="support@up42.com",
     description="Evaluation metrics to assess the similarity between two images.",


### PR DESCRIPTION
UIQ is computed on windows of the input arrays. We are skipping any array window that doesn't have the full shape of the window (i.e. when the array is smaller than the window size given). This causes the final UIQ result to be Null. With this change a ValueError will be raised informing the user to decrease the window size to fit the image. In addition the org_img array is converted to float to avoid underfloating of some data types.