### PR TITLE
Use nan to 0 in computing SAM mean

### DIFF
--- a/image_similarity_measures/quality_metrics.py
+++ b/image_similarity_measures/quality_metrics.py
@@ -264,7 +264,7 @@ def sam(org_img: np.ndarray, pred_img: np.ndarray, convert_to_degree=True):
 
     # The original paper states that SAM values are expressed as radians, while e.g. Lanares
     # et al. (2018) use degrees. We therefore made this configurable, with degree the default
-    return np.mean(sam_angles)
+    return np.mean(np.nan_to_num(sam_angles))
 
 
 def sre(org_img: np.ndarray, pred_img: np.ndarray):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="image-similarity-measures",
-    version="0.3.1",
+    version="0.3.2",
     author="UP42",
     author_email="support@up42.com",
     description="Evaluation metrics to assess the similarity between two images.",


### PR DESCRIPTION
When denominator is zero in SAM computation (for instance when the image has black fill 0) the result includes nan which results in nan mean. Introducing `np.nan_to_num` that returns zero before computing mean of SAM.