### PR TITLE
Mark as compatible with Python 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Implementation of eight evaluation metrics to access the similarity between two 
 
 The following step-by-step instructions will guide you through installing this package and run evaluation using the command line tool.
 
-**Note:** Supported python versions are 3.6, 3.7, 3.8.
+**Note:** Supported python versions are 3.6, 3.7, 3.8, and 3.9.
 
 ### Install package
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
         "Development Status :: 5 - Production/Stable"
     ],
     install_requires=["numpy", "rasterio", "scikit-image", "opencv-python", "pyfftw", "phasepack"],
-    python_requires=">=3.6, <3.9",
+    python_requires=">=3.6, <3.10",
     entry_points = {
         'console_scripts': ['image-similarity-measures=image_similarity_measures.evaluate:main'],
     }


### PR DESCRIPTION
The package works just fine with Python 3.9.

The only caveat is that there may not be Python 3.9 wheels for the requisite pyfftw library (see https://github.com/pyFFTW/pyFFTW/issues/301).