### PR TITLE
Add GitHub CI workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,35 @@
+name: Python
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9"]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Upgrade Python bits
+      run: |
+        python -m pip install --upgrade pip coverage wheel setuptools
+    - name: Install development files
+      if: matrix.python-version == '3.9'
+      run: |
+        sudo apt-get install -y fftw3-dev
+        python -m pip install Cython
+    - name: Install app
+      run: python -m pip install --ignore-requires-python -e .
+    - name: Run app with coverage
+      run: coverage run -m image_similarity_measures.evaluate --org_img_path=example/lafayette_org.tif --pred_img_path=example/lafayette_pred.tif --mode=tif
+    - name: Report coverage
+      continue-on-error: true
+      run: coverage report


### PR DESCRIPTION
This GitHub Actions workflow ensures that the CLI script runs, which is better than nothing in the absence of proper tests :) 

Ties into #19 in the sense that the CI workflow also runs on 3.9.

You can see this in action over at https://github.com/akx/image-similarity-measures/pull/1 (since closed in favor of this PR).