### PR TITLE
CLI tool improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ pip install image-similarity-measures
   --pred_img_path FILE  Path to predicted image
   --metric METRIC       select an evaluation metric (fsim, issm, psnr, rmse,
                         sam, sre, ssim, uiq, all) (can be repeated)
-  --write_to_file       final output will be written to a file.
 ```
 
 #### Evaluation
@@ -38,7 +37,7 @@ For doing the evaluation, you can easily run the following command:
 ```bash
 image-similarity-measures --org_img_path=a.tif --pred_img_path=b.tif
 ```
-If you want to save the final result in a file you can add `--write_to_file` at then end of above command.
+The results are printed in machine-readable JSON, so you can redirect the output of the command into a file.
 
 **Note** that images that are used for evaluation should be **channel last**.
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ pip install image-similarity-measures
 ```
   --org_img_path FILE   Path to original input image
   --pred_img_path FILE  Path to predicted image
-  --metric METRIC       use psnr, ssim, fsim, issm, uiq, sam, sre or rmse as
-                        evaluation metric
+  --metric METRIC       select an evaluation metric (fsim, issm, psnr, rmse,
+                        sam, sre, ssim, uiq, all) (can be repeated)
   --mode MODE           format of image, use either tif, or png, or jpg
   --write_to_file       final output will be written to a file.
+
 ```
 
 #### Evaluation

--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ pip install image-similarity-measures
 ### Usage
 #### Parameters
 ```
---org_img_path : Path to the original image.
---pred_img_path : Path to the predicted or disordered image which is created from the original image.
---metric= : Name of the evaluation metric. Default set to be psnr. It can be one of the following: psnr, ssim, issm, fsim.
---mode : Image format. Default set to be "tif". can be one of the following: "tif", or "png", or "jpg".
---write_to_file : The final result will be written to a file. Set to False if you don't want a final file.
+  --org_img_path FILE   Path to original input image
+  --pred_img_path FILE  Path to predicted image
+  --metric METRIC       use psnr, ssim, fsim, issm, uiq, sam, sre or rmse as
+                        evaluation metric
+  --mode MODE           format of image, use either tif, or png, or jpg
+  --write_to_file       final output will be written to a file.
 ```
 
 #### Evaluation

--- a/README.md
+++ b/README.md
@@ -29,15 +29,14 @@ pip install image-similarity-measures
   --pred_img_path FILE  Path to predicted image
   --metric METRIC       select an evaluation metric (fsim, issm, psnr, rmse,
                         sam, sre, ssim, uiq, all) (can be repeated)
-  --mode MODE           format of image, use either tif, or png, or jpg
   --write_to_file       final output will be written to a file.
-
 ```
 
 #### Evaluation
 For doing the evaluation, you can easily run the following command:
+
 ```bash
-image-similarity-measures --org_img_path=path_to_first_img --pred_img_path=path_to_second_img --mode=tif
+image-similarity-measures --org_img_path=a.tif --pred_img_path=b.tif
 ```
 If you want to save the final result in a file you can add `--write_to_file` at then end of above command.
 

--- a/image_similarity_measures/evaluate.py
+++ b/image_similarity_measures/evaluate.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 import os
 
@@ -11,16 +12,6 @@ from image_similarity_measures.quality_metrics import metric_functions
 logger = logging.getLogger(__name__)
 
 
-def write_final_dict(metric, metric_dict):
-    # Create a directory to save the text file of including evaluation values.
-    predict_path = "metrics_value/"
-    if not os.path.exists(predict_path):
-        os.makedirs(predict_path)
-
-    with open(os.path.join(predict_path, metric + '.txt'), 'w') as f:
-        f.writelines('{}\n'.format(v) for _, v in metric_dict.items())
-
-
 def read_image(path):
     logger.info("Reading image %s", os.path.basename(path))
     if path.endswith(".tif") or path.endswith(".tiff"):
@@ -28,17 +19,17 @@ def read_image(path):
     return cv2.imread(path)
 
 
-def evaluation(org_img_path, pred_img_path, metrics, write_to_file):
+def evaluation(org_img_path, pred_img_path, metrics):
+    output_dict = {}
     org_img = read_image(org_img_path)
     pred_img = read_image(pred_img_path)
 
     for metric in metrics:
         metric_func = metric_functions[metric]
-        out_value = metric_func(org_img, pred_img)
+        out_value = float(metric_func(org_img, pred_img))
         logger.info(f"{metric.upper()} value is: {out_value}")
-        if write_to_file:
-            metric_dict = {metric: {f"{metric.upper()}": out_value}}
-            write_final_dict(metric, metric_dict)
+        output_dict[metric] = out_value
+    return output_dict
 
 
 def main():
@@ -53,19 +44,20 @@ def main():
     parser.add_argument("--metric", dest="metrics", action="append",
                         choices=all_metrics + ['all'], metavar="METRIC",
                         help="select an evaluation metric (%(choices)s) (can be repeated)")
-    parser.add_argument("--write_to_file", action="store_true", help="final output will be written to a file.")
     args = parser.parse_args()
     if not args.metrics:
         args.metrics = ["psnr"]
     if "all" in args.metrics:
         args.metrics = all_metrics
 
-    evaluation(
+    metric_values = evaluation(
         org_img_path=args.org_img_path,
         pred_img_path=args.pred_img_path,
         metrics=args.metrics,
-        write_to_file=args.write_to_file,
     )
+    result_dict = {"image1": args.org_img_path, "image2": args.pred_img_path, "metrics": metric_values}
+    print(json.dumps(result_dict, sort_keys=True))
+
 
 if __name__ == "__main__":
     main()

--- a/image_similarity_measures/evaluate.py
+++ b/image_similarity_measures/evaluate.py
@@ -1,31 +1,14 @@
-import os
 import argparse
+import logging
+import os
+
+import cv2
 import numpy as np
 import rasterio as rio
-import cv2
 
 from image_similarity_measures.quality_metrics import metric_functions
 
-import logging
-LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-
-
-def get_logger(name, level=logging.DEBUG):
-    """
-    This method creates logger object and sets the default log level to DEBUG.
-    """
-    logger = logging.getLogger(name)
-    logger.setLevel(level)
-    # create console handler and set level to debug
-    c_h = logging.StreamHandler()
-    c_h.setLevel(level)
-    formatter = logging.Formatter(LOG_FORMAT)
-    c_h.setFormatter(formatter)
-    logger.addHandler(c_h)
-    return logger
-
-
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def write_final_dict(metric, metric_dict):
@@ -59,6 +42,10 @@ def evaluation(org_img_path, pred_img_path, metrics, write_to_file):
 
 
 def main():
+    logging.basicConfig(
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        level=logging.INFO,
+    )
     all_metrics = sorted(metric_functions.keys())
     parser = argparse.ArgumentParser(description="Evaluates an Image Super Resolution Model")
     parser.add_argument("--org_img_path", help="Path to original input image", required=True, metavar="FILE")

--- a/image_similarity_measures/evaluate.py
+++ b/image_similarity_measures/evaluate.py
@@ -81,25 +81,21 @@ def evaluation(org_img_path, pred_img_path, mode, metric, write_to_file):
 
 def main():
     parser = argparse.ArgumentParser(description="Evaluates an Image Super Resolution Model")
-    parser.add_argument("--org_img_path", type=str, help="Path to original input image")
-    parser.add_argument("--pred_img_path", help="Path to predicted images")
-    parser.add_argument("--metric", type=str, default="psnr", help=("use psnr, ssim, fsim, issm, uiq,"
+    parser.add_argument("--org_img_path", help="Path to original input image", required=True, metavar="FILE")
+    parser.add_argument("--pred_img_path", help="Path to predicted image", required=True, metavar="FILE")
+    parser.add_argument("--metric", default="psnr", help=("use psnr, ssim, fsim, issm, uiq,"
                                                                    " sam, sre or rmse as evaluation metric"))
-    parser.add_argument("--mode", type=str, default="tif", help="format of image, use either tif, or png, or jpg")
+    parser.add_argument("--mode", default="tif", help="format of image, use either tif, or png, or jpg")
     parser.add_argument("--write_to_file", action="store_true", help="final output will be written to a file.")
     args = parser.parse_args()
 
-    if len(sys.argv)==1:
-        parser.print_help()
-        parser.exit()
-
-    orgpath = args.org_img_path
-    predpath = args.pred_img_path
-    metric = args.metric
-    mode = args.mode
-    write_to_file = args.write_to_file
-
-    evaluation(orgpath, predpath, mode, metric, write_to_file)
+    evaluation(
+        org_img_path=args.org_img_path,
+        pred_img_path=args.pred_img_path,
+        metric=args.metric,
+        mode=args.mode,
+        write_to_file=args.write_to_file,
+    )
 
 if __name__ == "__main__":
     main()

--- a/image_similarity_measures/evaluate.py
+++ b/image_similarity_measures/evaluate.py
@@ -8,7 +8,7 @@ import numpy as np
 import rasterio as rio
 import cv2
 
-from image_similarity_measures.quality_metrics import psnr, ssim, fsim, issm, uiq, sam, sre, rmse
+from image_similarity_measures.quality_metrics import metric_functions
 
 import logging
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -56,8 +56,7 @@ def write_final_dict(metric, metric_dict):
         f.writelines('{}\n'.format(v) for _, v in metric_dict.items())
 
 
-def evaluation(org_img_path, pred_img_path, mode, metric, write_to_file):
-    metric_dict = {}
+def evaluation(org_img_path, pred_img_path, mode, metrics, write_to_file):
 
     if mode == "tif":
         logging.info("Reading image %s", Path(org_img_path).stem)
@@ -71,28 +70,35 @@ def evaluation(org_img_path, pred_img_path, mode, metric, write_to_file):
         logging.info("Reading image %s", Path(pred_img_path).stem)
         pred_img = read_png(pred_img_path)
 
-
-    out_value = eval(f"{metric}(org_img, pred_img)")
-    logger.info(f"{metric.upper()} value is: {out_value}")
-    if write_to_file:
-        metric_dict[metric] = {f"{metric.upper()}": out_value}
-        write_final_dict(metric, metric_dict)
+    for metric in metrics:
+        metric_func = metric_functions[metric]
+        out_value = metric_func(org_img, pred_img)
+        logger.info(f"{metric.upper()} value is: {out_value}")
+        if write_to_file:
+            metric_dict = {metric: {f"{metric.upper()}": out_value}}
+            write_final_dict(metric, metric_dict)
 
 
 def main():
+    all_metrics = sorted(metric_functions.keys())
     parser = argparse.ArgumentParser(description="Evaluates an Image Super Resolution Model")
     parser.add_argument("--org_img_path", help="Path to original input image", required=True, metavar="FILE")
     parser.add_argument("--pred_img_path", help="Path to predicted image", required=True, metavar="FILE")
-    parser.add_argument("--metric", default="psnr", help=("use psnr, ssim, fsim, issm, uiq,"
-                                                                   " sam, sre or rmse as evaluation metric"))
-    parser.add_argument("--mode", default="tif", help="format of image, use either tif, or png, or jpg")
+    parser.add_argument("--metric", dest="metrics", action="append",
+                        choices=all_metrics + ['all'], metavar="METRIC",
+                        help="select an evaluation metric (%(choices)s) (can be repeated)")
+    parser.add_argument("--mode",  default="tif", help="format of image, use either tif, or png, or jpg")
     parser.add_argument("--write_to_file", action="store_true", help="final output will be written to a file.")
     args = parser.parse_args()
+    if not args.metrics:
+        args.metrics = ["psnr"]
+    if "all" in args.metrics:
+        args.metrics = all_metrics
 
     evaluation(
         org_img_path=args.org_img_path,
         pred_img_path=args.pred_img_path,
-        metric=args.metric,
+        metrics=args.metrics,
         mode=args.mode,
         write_to_file=args.write_to_file,
     )

--- a/image_similarity_measures/quality_metrics.py
+++ b/image_similarity_measures/quality_metrics.py
@@ -283,3 +283,14 @@ def sre(org_img: np.ndarray, pred_img: np.ndarray):
         sre_final.append(numerator/denominator)
 
     return 10 * np.log10(np.mean(sre_final))
+
+metric_functions = {
+    "fsim": fsim,
+    "issm": issm,
+    "psnr": psnr,
+    "rmse": rmse,
+    "sam": sam,
+    "sre": sre,
+    "ssim": ssim,
+    "uiq": uiq,
+}


### PR DESCRIPTION
This PR simplifies the CLI tool a bit, as well as adds new features. Some unnecessary options were removed, and the readme has been updated accordingly.

The user-visible changes are:

* `--mode` is no longer necessary (or allowed), files with a `.tif` or `.tiff` extension are read using the TIFF code. This also allows mixing and matching TIFF/non-TIFF images.
* `--metric` can be repeated, or `all` can be specified.
* The `--write_to_file` option was removed, since it didn't really make much sense especially with the introduction of multiple metrics. Instead, the tool always outputs information as machine-readable JSON at the end of the run, and that information can readily be redirected into a file. Since the information contains the file names evaluated, it can even be appended into a [JSON Lines](https://jsonlines.org/) style file.