### PR TITLE
Empty out __init__.py

### DIFF
--- a/image_similarity_measures/__init__.py
+++ b/image_similarity_measures/__init__.py
@@ -1,2 +1,0 @@
-import image_similarity_measures.evaluate
-import image_similarity_measures.quality_metrics


### PR DESCRIPTION
It does not need to import the submodules for things to work. This also squelches a warning output by Python:

> RuntimeWarning: 'image_similarity_measures.evaluate' found in sys.modules after import of package 'image_similarity_measures', but prior to execution of 'image_similarity_measures.evaluate'; this may result in unpredictable behaviour
