### PR TITLE
Make pyfftw and rasterio extra dependencies

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install app
       run: python -m pip install --ignore-requires-python -e .
     - name: Run app with coverage
-      run: coverage run -m image_similarity_measures.evaluate --org_img_path=example/lafayette_org.tif --pred_img_path=example/lafayette_pred.tif
+      run: coverage run -m image_similarity_measures.evaluate --metric all --org_img_path=example/lafayette_org.tif --pred_img_path=example/lafayette_pred.tif
     - name: Report coverage
       continue-on-error: true
       run: coverage report

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,6 +12,10 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9"]
+        extras:
+          - ''
+          - '[speedups]'
+          - '[speedups,rasterio]'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -27,7 +31,9 @@ jobs:
         sudo apt-get install -y fftw3-dev
         python -m pip install Cython
     - name: Install app
-      run: python -m pip install --ignore-requires-python -e .
+      run: python -m pip install --ignore-requires-python -e ."$EXTRAS"
+      env:
+        EXTRAS: '${{ matrix.extras }}'
     - name: Run app with coverage
       run: coverage run -m image_similarity_measures.evaluate --metric all --org_img_path=example/lafayette_org.tif --pred_img_path=example/lafayette_pred.tif
     - name: Report coverage

--- a/README.md
+++ b/README.md
@@ -18,11 +18,29 @@ The following step-by-step instructions will guide you through installing this p
 **Note:** Supported python versions are 3.6, 3.7, 3.8, and 3.9.
 
 ### Install package
+
 ```bash
 pip install image-similarity-measures
 ```
 
+For faster evaluation of the FSIM metric, the `pyfftw` package is required.
+You can install it separately, or via the `speedups` extra:
+
+```bash
+pip install image-similarity-measures[speedups]
+```
+
+You may also install the `rasterio` package to allow the CLI tool to use it for reading TIFF
+images instead of OpenCV. It, too, is available as an extra:
+
+
+```bash
+pip install image-similarity-measures[rasterio]
+```
+
+
 ### Usage
+
 #### Parameters
 ```
   --org_img_path FILE   Path to original input image

--- a/image_similarity_measures/evaluate.py
+++ b/image_similarity_measures/evaluate.py
@@ -5,7 +5,11 @@ import os
 
 import cv2
 import numpy as np
-import rasterio as rio
+
+try:
+    import rasterio
+except ImportError:
+    rasterio = None
 
 from image_similarity_measures.quality_metrics import metric_functions
 
@@ -14,8 +18,8 @@ logger = logging.getLogger(__name__)
 
 def read_image(path):
     logger.info("Reading image %s", os.path.basename(path))
-    if path.endswith(".tif") or path.endswith(".tiff"):
-        return np.rollaxis(rio.open(path).read(), 0, 3)
+    if rasterio and (path.endswith(".tif") or path.endswith(".tiff")):
+        return np.rollaxis(rasterio.open(path).read(), 0, 3)
     return cv2.imread(path)
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,13 @@ setuptools.setup(
         "Intended Audience :: Science/Research",
         "Development Status :: 5 - Production/Stable"
     ],
-    install_requires=["numpy", "rasterio", "scikit-image", "opencv-python", "pyfftw", "phasepack"],
+    extras_require={
+        "rasterio": ["rasterio"],
+        "speedups": ["pyfftw"],
+    },
+    install_requires=["numpy", "scikit-image", "opencv-python", "phasepack"],
     python_requires=">=3.6, <3.10",
     entry_points = {
         'console_scripts': ['image-similarity-measures=image_similarity_measures.evaluate:main'],
-    }
+    },
 )


### PR DESCRIPTION
This will make the installation footprint of the package smaller by default.

* pyFFTW not strictly required; it's just a faster FFT backend (used by Phasepack, hence by the FSIM metric).
  * In addition, since FFTW is licensed under the GPL, a strict dependency on pyFFTW (a GPL wrapper) would also make any application using it require GPL (or [purchasing a license for FFTW](https://tlo.mit.edu/technologies/fftw-fastest-fourier-transform-west)). See https://github.com/pyFFTW/pyFFTW/issues/229 for discussion. Making it a soft dependency allows this library to remain neatly MIT.
* rasterio is only needed for reading TIFFs in an... alternate way, it seems? I guess it has to do with some multi-channel TIFFs? Either way, it's not required for using the package as a library (which I'm doing, for instance).

This also expands the GHA workflow to:

* test <del>all</del> three out of four of these configurations (no extras, speedups, speedups + rasterio).
* test all the metrics