### PR TITLE
Remove upper bound on python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
         "speedups": ["pyfftw"],
     },
     install_requires=["numpy", "scikit-image", "opencv-python", "phasepack"],
-    python_requires=">=3.6, <3.10",
+    python_requires=">=3.6",
     entry_points={
         "console_scripts": [
             "image-similarity-measures=image_similarity_measures.evaluate:main"


### PR DESCRIPTION
It's likely that the package will work fine on newer Pythons.

CI is not passing due to Numpy version shenanigans, but #43 oughta fix that right up.