### PR TITLE
Change e in ISSM to 0.01. Add normalisation for ehs, add correct bins.

### DIFF
--- a/image_similarity_measures/quality_metrics.py
+++ b/image_similarity_measures/quality_metrics.py
@@ -166,7 +166,13 @@ def _ehs(x: np.ndarray, y: np.ndarray):
     """
     Entropy-Histogram Similarity measure
     """
-    H = (np.histogram2d(x.flatten(), y.flatten()))[0]
+    total_pixels = x.size
+
+    # Original paper operates with entropy specified for images with value range from 0 to 255
+    # bins must be set accordingly
+    value_bins = list(range(256))
+
+    H = (np.histogram2d(x.flatten(), y.flatten(), bins=[value_bins, value_bins]))[0] / total_pixels
 
     return -np.sum(np.nan_to_num(H * np.log2(H)))
 
@@ -203,12 +209,13 @@ def issm(org_img: np.ndarray, pred_img: np.ndarray) -> float:
     A = 0.3
     B = 0.5
     C = 0.7
+    e = 0.01
 
     ehs_val = _ehs(x, y)
     canny_val = _edge_c(x, y)
 
-    numerator = canny_val * ehs_val * (A + B) + math.e
-    denominator = A * canny_val * ehs_val + B * ehs_val + C * ssim(x, y) + math.e
+    numerator = canny_val * ehs_val * (A + B) + e
+    denominator = A * canny_val * ehs_val + B * ehs_val + C * ssim(x, y) + e
 
     return np.nan_to_num(numerator / denominator)
 


### PR DESCRIPTION
I've found  paper which mentions the mystery coeficient e. It's mentioned in Shnain, N.A., Hussain, Z.M., & Lu, S.F. (2017). A feature-based structural measure: An image similarity measure for face recognition [J].
(https://www.mdpi.com/2076-3417/7/8/786)

Its value is then equal to 0.01. I've also implemented changes for normalisation of the ehs and added argument for bins, since theoretically value space ranges from 0 to 255(without arg it defaults to 10, which gives skewed results).

Would be great if somebody could test it and verify this now works as intended. :]

